### PR TITLE
feat: basic help message

### DIFF
--- a/molter/help.py
+++ b/molter/help.py
@@ -65,7 +65,7 @@ class HelpCommand:
 
         self._client.add_message_command(self._cmd)  # type: ignore
 
-    async def send_help(self, ctx: MessageContext, cmd_name: str | None) -> None:
+    async def send_help(self, ctx: MessageContext, *, cmd_name: str | None) -> None:
         """
         Send a help message to the given context.
 

--- a/molter/help.py
+++ b/molter/help.py
@@ -63,7 +63,7 @@ class HelpCommand:
 
         self._client.add_message_command(self._cmd)  # type: ignore
 
-    async def send_help(self, ctx: MessageContext, *, cmd_name: str | None) -> None:
+    async def send_help(self, ctx: MessageContext, cmd_name: str | None) -> None:
         """
         Send a help message to the given context.
 

--- a/molter/help.py
+++ b/molter/help.py
@@ -7,6 +7,8 @@ from dis_snek.ext.paginators import Paginator
 
 import molter
 
+__all__ = ("HelpCommand",)
+
 log = logging.getLogger(dis_snek.const.logger_name)
 
 
@@ -45,7 +47,7 @@ class HelpCommand:
         show_prefix: bool = False,
         embed_title: str | None = None,
         not_found_message: str | None = None,
-    ):
+    ) -> None:
         self._client = client
         self.show_hidden = show_hidden
         self.run_checks = run_checks

--- a/molter/help.py
+++ b/molter/help.py
@@ -46,9 +46,9 @@ class HelpCommand:
     _client: "Snake" = attrs.field()
     _cmd: molter.MolterCommand | None = attrs.field(init=False, default=None)
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         if not self._cmd:
-            self._cmd = self._callback
+            self._cmd = self._callback  # type: ignore
 
     def register(self) -> None:
         """Register the help command in dis-snek"""

--- a/molter/help.py
+++ b/molter/help.py
@@ -77,7 +77,7 @@ class HelpCommand:
         Send a help message to the given context.
 
         args:
-            ctx: The context to use
+            ctx: The context to use.
             cmd_name: An optional command name to send help for.
         """
         await self._callback.callback(ctx, cmd_name)  # type: ignore

--- a/molter/help.py
+++ b/molter/help.py
@@ -74,7 +74,7 @@ class HelpCommand:
         await self._callback.callback(ctx, cmd_name)  # type: ignore
 
     @molter.msg_command(name="help")
-    async def _callback(self, ctx: MessageContext, cmd_name: str = None) -> None:
+    async def _callback(self, ctx: MessageContext, *, cmd_name: str = None) -> None:
         if cmd_name:
             return await self._help_specific(ctx, cmd_name)
         await self._help_list(ctx)

--- a/molter/help.py
+++ b/molter/help.py
@@ -14,24 +14,24 @@ log = logging.getLogger(dis_snek.const.logger_name)
 
 class HelpCommand:
     show_hidden: bool
-    """Should hidden commands be shown"""
+    """Should hidden commands be shown?"""
     show_disabled: bool
-    """Should disabled commands be shown"""
+    """Should disabled commands be shown?"""
     run_checks: bool
-    """Should only commands that's checks pass be shown"""
+    """Should commands be checked if they can be run by the help command user?"""
     show_self: bool
-    """Should this command be shown in the help message"""
+    """Should this command be shown in the help message?"""
     show_params: bool
-    """Should parameters for commands be shown"""
+    """Should parameters for commands be shown?"""
     show_aliases: bool
-    """Should aliases for commands be shown"""
+    """Should aliases for commands be shown?"""
     show_prefix: bool
-    """Should the prefix be shown"""
+    """Should the prefix be shown?"""
 
     embed_title: str
-    """The title to use in the embed. {username} will be replaced by the client's username"""
+    """The title to use in the embed. {username} will be replaced by the client's username."""
     not_found_message: str
-    """The message to send when a command was not found. {cmd_name} will be replaced by the requested command."""
+    """The message to send when a command is not found. {cmd_name} will be replaced by the requested command."""
 
     _client: dis_snek.Snake
 
@@ -60,7 +60,7 @@ class HelpCommand:
         self.cmd = self._callback
 
     def register(self) -> None:
-        """Register the help command in dis-snek"""
+        """Register the help command in dis-snek."""
         if not isinstance(self.cmd.callback, functools.partial):
             # prevent wrap-nesting
             self.cmd.callback = functools.partial(self.cmd.callback, self)
@@ -78,7 +78,7 @@ class HelpCommand:
 
         args:
             ctx: The context to use
-            cmd_name: An optional command name to send help for
+            cmd_name: An optional command name to send help for.
         """
         await self._callback.callback(ctx, cmd_name)  # type: ignore
 
@@ -121,13 +121,13 @@ class HelpCommand:
 
     async def _gather(self, ctx: dis_snek.MessageContext | None = None) -> dict[str, molter.MolterCommand]:
         """
-        Gather commands based on the rules set out in the class attribs
+        Gather commands based on the rules set out in the class attributes.
 
         args:
-            ctx: The context to use to establish usability
+            ctx: The context to use to establish usability.
 
         returns:
-            dict[str, MolterCommand]: A list of commands fit the class attrib configuration
+            dict[str, MolterCommand]: A list of commands fit the class attribute configuration.
         """
         out: dict[str, molter.MolterCommand] = {}
 
@@ -163,7 +163,7 @@ class HelpCommand:
         Replace mentions with a format that won't ping or look weird in code blocks.
 
         args:
-            The text to sanitise
+            The text to sanitise.
         """
         mappings = {
             "@everyone": "@\u200beveryone",
@@ -181,8 +181,8 @@ class HelpCommand:
         Generate a string based on a command, class attributes, and the context.
 
         args:
-            cmd: The command in question
-            ctx:
+            cmd: The command in question.
+            ctx: The context for this command.
         """
         _temp = f"`{ctx.prefix if self.show_prefix else ''}{cmd.qualified_name}`"
 

--- a/molter/help.py
+++ b/molter/help.py
@@ -54,9 +54,7 @@ class HelpCommand:
         self.show_aliases = show_aliases
         self.show_prefix = show_prefix
         self.embed_title = embed_title or "{username} Help Command"
-        self.not_found_message = (
-            not_found_message or "Sorry! No command called `{cmd_name}` was found."
-        )
+        self.not_found_message = not_found_message or "Sorry! No command called `{cmd_name}` was found."
         self.cmd = self._callback
 
     def register(self) -> None:
@@ -72,9 +70,7 @@ class HelpCommand:
 
         self._client.add_message_command(self.cmd)  # type: ignore
 
-    async def send_help(
-        self, ctx: dis_snek.MessageContext, cmd_name: str | None
-    ) -> None:
+    async def send_help(self, ctx: dis_snek.MessageContext, cmd_name: str | None) -> None:
         """
         Send a help message to the given context.
 
@@ -85,9 +81,7 @@ class HelpCommand:
         await self._callback.callback(ctx, cmd_name)  # type: ignore
 
     @molter.msg_command(name="help")
-    async def _callback(
-        self, ctx: dis_snek.MessageContext, cmd_name: str = None
-    ) -> None:
+    async def _callback(self, ctx: dis_snek.MessageContext, cmd_name: str = None) -> None:
         if cmd_name:
             return await self._help_specific(ctx, cmd_name)
         await self._help_list(ctx)
@@ -103,9 +97,7 @@ class HelpCommand:
             output.append(self._sanitise_mentions(_temp))
         if len("\n".join(output)) > 500:
             paginator = Paginator.create_from_list(self._client, output, page_size=500)
-            paginator.default_title = self.embed_title.format(
-                username=self._client.user.username
-            )
+            paginator.default_title = self.embed_title.format(username=self._client.user.username)
             await paginator.send(ctx)
         else:
             embed = Embed(
@@ -125,9 +117,7 @@ class HelpCommand:
         else:
             await ctx.reply(self.not_found_message.format(cmd_name=cmd_name))
 
-    async def _gather(
-        self, ctx: dis_snek.MessageContext | None = None
-    ) -> dict[str, molter.MolterCommand]:
+    async def _gather(self, ctx: dis_snek.MessageContext | None = None) -> dict[str, molter.MolterCommand]:
         """
         Gather commands based on the rules set out in the class attribs
 
@@ -184,9 +174,7 @@ class HelpCommand:
 
         return text
 
-    def _generate_command_string(
-        self, cmd: molter.MolterCommand, ctx: dis_snek.MessageContext
-    ) -> str:
+    def _generate_command_string(self, cmd: molter.MolterCommand, ctx: dis_snek.MessageContext) -> str:
         """
         Generate a string based on a command, class attributes, and the context.
 

--- a/molter/help.py
+++ b/molter/help.py
@@ -139,7 +139,7 @@ class HelpCommand:
             if cmd == self._cmd and not self.show_self:
                 continue
 
-            elif cmd.hidden and not self.show_hidden:
+            if cmd.hidden and not self.show_hidden:
                 continue
 
             if ctx and cmd.checks and not self.run_checks:

--- a/molter/help.py
+++ b/molter/help.py
@@ -40,9 +40,7 @@ class HelpCommand:
 
     embed_title: str = attrs.field(default="{username} Help Command", kw_only=True)
     """The title to use in the embed. {username} will be replaced by the client's username"""
-    not_found_message: str = attrs.field(
-        default="Sorry! No command called `{cmd_name}` was found.", kw_only=True
-    )
+    not_found_message: str = attrs.field(default="Sorry! No command called `{cmd_name}` was found.", kw_only=True)
     """The message to send when a command was not found. {cmd_name} will be replaced by the requested command."""
 
     _client: "Snake" = attrs.field()
@@ -93,9 +91,7 @@ class HelpCommand:
         if len("\n".join(output)) > 500:
             paginator = Paginator.create_from_list(self._client, output, page_size=500)
             paginator.default_color = self.embed_color
-            paginator.default_title = self.embed_title.format(
-                username=self._client.user.username
-            )
+            paginator.default_title = self.embed_title.format(username=self._client.user.username)
             await paginator.send(ctx)
         else:
             embed = Embed(
@@ -115,9 +111,7 @@ class HelpCommand:
         else:
             await ctx.reply(self.not_found_message.format(cmd_name=cmd_name))
 
-    async def _gather(
-        self, ctx: MessageContext | None = None
-    ) -> dict[str, molter.MolterCommand]:
+    async def _gather(self, ctx: MessageContext | None = None) -> dict[str, molter.MolterCommand]:
         """
         Gather commands based on the rules set out in the class attributes.
 
@@ -175,9 +169,7 @@ class HelpCommand:
 
         return text
 
-    def _generate_command_string(
-        self, cmd: molter.MolterCommand, ctx: MessageContext
-    ) -> str:
+    def _generate_command_string(self, cmd: molter.MolterCommand, ctx: MessageContext) -> str:
         """
         Generate a string based on a command, class attributes, and the context.
 

--- a/molter/help.py
+++ b/molter/help.py
@@ -1,0 +1,207 @@
+import functools
+import logging
+
+import dis_snek
+from dis_snek import Embed
+from dis_snek.ext.paginators import Paginator
+
+import molter
+
+log = logging.getLogger(dis_snek.const.logger_name)
+
+
+class HelpCommand:
+    show_hidden: bool
+    """Should hidden commands be shown"""
+    show_disabled: bool
+    """Should disabled commands be shown"""
+    run_checks: bool
+    """Should only commands that's checks pass be shown"""
+    show_self: bool
+    """Should this command be shown in the help message"""
+    show_params: bool
+    """Should parameters for commands be shown"""
+    show_aliases: bool
+    """Should aliases for commands be shown"""
+    show_prefix: bool
+    """Should the prefix be shown"""
+
+    embed_title: str
+    """The title to use in the embed. {username} will be replaced by the client's username"""
+    not_found_message: str
+    """The message to send when a command was not found. {cmd_name} will be replaced by the requested command."""
+
+    _client: dis_snek.Snake
+
+    def __init__(
+        self,
+        client: dis_snek.Snake,
+        *,
+        show_hidden: bool = False,
+        run_checks: bool = False,
+        show_self: bool = False,
+        show_params: bool = False,
+        show_aliases: bool = False,
+        show_prefix: bool = False,
+        embed_title: str | None = None,
+        not_found_message: str | None = None,
+    ):
+        self._client = client
+        self.show_hidden = show_hidden
+        self.run_checks = run_checks
+        self.show_self = show_self
+        self.show_params = show_params
+        self.show_aliases = show_aliases
+        self.show_prefix = show_prefix
+        self.embed_title = embed_title or "{username} Help Command"
+        self.not_found_message = (
+            not_found_message or "Sorry! No command called `{cmd_name}` was found."
+        )
+        self.cmd = self._callback
+
+    def register(self) -> None:
+        """Register the help command in dis-snek"""
+        if not isinstance(self.cmd.callback, functools.partial):
+            # prevent wrap-nesting
+            self.cmd.callback = functools.partial(self.cmd.callback, self)
+
+        # replace existing help command if found
+        if "help" in self._client.commands:
+            log.warning("Replacing existing help command.")
+            del self._client.commands["help"]
+
+        self._client.add_message_command(self.cmd)  # type: ignore
+
+    async def send_help(
+        self, ctx: dis_snek.MessageContext, cmd_name: str | None
+    ) -> None:
+        """
+        Send a help message to the given context.
+
+        args:
+            ctx: The context to use
+            cmd_name: An optional command name to send help for
+        """
+        await self._callback.callback(ctx, cmd_name)  # type: ignore
+
+    @molter.msg_command(name="help")
+    async def _callback(
+        self, ctx: dis_snek.MessageContext, cmd_name: str = None
+    ) -> None:
+        if cmd_name:
+            return await self._help_specific(ctx, cmd_name)
+        await self._help_list(ctx)
+
+    async def _help_list(self, ctx: dis_snek.MessageContext) -> None:
+        cmds = await self._gather(ctx)
+
+        output = []
+        for cmd in cmds.values():
+            _temp = self._generate_command_string(cmd, ctx)
+            _temp += f"\n{cmd.brief}"
+
+            output.append(self._sanitise_mentions(_temp))
+        if len("\n".join(output)) > 500:
+            paginator = Paginator.create_from_list(self._client, output, page_size=500)
+            paginator.default_title = self.embed_title.format(
+                username=self._client.user.username
+            )
+            await paginator.send(ctx)
+        else:
+            embed = Embed(
+                title=self.embed_title.format(username=self._client.user.username),
+                description="\n".join(output),
+                color=dis_snek.BrandColors.BLURPLE,
+            )
+            await ctx.reply(embeds=embed)
+
+    async def _help_specific(self, ctx: dis_snek.MessageContext, cmd_name: str) -> None:
+        cmds = await self._gather(ctx)
+
+        if cmd := cmds.get(cmd_name.lower()):
+            _temp = self._generate_command_string(cmd, ctx)
+            _temp += f"\n{cmd.help}"
+            await ctx.reply(self._sanitise_mentions(_temp))
+        else:
+            await ctx.reply(self.not_found_message.format(cmd_name=cmd_name))
+
+    async def _gather(
+        self, ctx: dis_snek.MessageContext | None = None
+    ) -> dict[str, molter.MolterCommand]:
+        """
+        Gather commands based on the rules set out in the class attribs
+
+        args:
+            ctx: The context to use to establish usability
+
+        returns:
+            dict[str, MolterCommand]: A list of commands fit the class attrib configuration
+        """
+        out: dict[str, molter.MolterCommand] = {}
+
+        for cmd in self._client.commands.values():
+            cmd: molter.MolterCommand
+
+            if not cmd.enabled and not self.show_disabled:
+                continue
+
+            if cmd == self.cmd and not self.show_self:
+                continue
+
+            elif cmd.hidden and not self.show_hidden:
+                continue
+
+            if ctx and cmd.checks and not self.run_checks:
+                # cmd._can_run would check the cooldowns, we don't want that so manual calling is required
+                for _c in cmd.checks:
+                    if not await _c(ctx):
+                        continue
+
+                if cmd.scale and cmd.scale.scale_checks:
+                    for _c in cmd.scale.scale_checks:
+                        if not await _c(ctx):
+                            continue
+
+            out[cmd.qualified_name] = cmd
+
+        return out
+
+    def _sanitise_mentions(self, text: str) -> str:
+        """
+        Replace mentions with a format that won't ping or look weird in code blocks.
+
+        args:
+            The text to sanitise
+        """
+        mappings = {
+            "@everyone": "@\u200beveryone",
+            "@here": "@\u200bhere",
+            f"<@{self._client.user.id}>": f"@{self._client.user.username}",
+            f"<@!{self._client.user.id}>": f"@{self._client.user.username}",
+        }
+        for source, target in mappings.items():
+            text = text.replace(source, target)
+
+        return text
+
+    def _generate_command_string(
+        self, cmd: molter.MolterCommand, ctx: dis_snek.MessageContext
+    ) -> str:
+        """
+        Generate a string based on a command, class attributes, and the context.
+
+        args:
+            cmd: The command in question
+            ctx:
+        """
+        _temp = f"`{ctx.prefix if self.show_prefix else ''}{cmd.qualified_name}`"
+
+        if cmd.aliases and self.show_aliases:
+            _temp += "|" + "|".join([f"`{a}`" for a in cmd.aliases])
+
+        if cmd.params and self.show_params:
+            for param in cmd.params:
+                wrapper = ("[", "]") if param.optional else ("<", ">")
+                _temp += f" `{wrapper[0]}{param.name}{wrapper[1]}`"
+
+        return _temp

--- a/molter/help.py
+++ b/molter/help.py
@@ -1,12 +1,12 @@
 import functools
 import logging
-from typing import TYPE_CHECKING, Coroutine
+from typing import TYPE_CHECKING
 
 import attrs
 from dis_snek import Embed
 from dis_snek.client.const import logger_name
 from dis_snek.ext.paginators import Paginator
-from dis_snek.models.discord.color import BrandColors
+from dis_snek.models.discord.color import BrandColors, Color
 from dis_snek.models.snek.context import MessageContext
 
 import molter
@@ -35,6 +35,8 @@ class HelpCommand:
     """Should aliases for commands be shown"""
     show_prefix: bool = attrs.field(default=False, kw_only=True)
     """Should the prefix be shown"""
+    embed_color: Color = attrs.field(default=BrandColors.BLURPLE, kw_only=True)
+    """The colour to show in the Embeds"""
 
     embed_title: str = attrs.field(default="{username} Help Command", kw_only=True)
     """The title to use in the embed. {username} will be replaced by the client's username"""
@@ -90,6 +92,7 @@ class HelpCommand:
             output.append(self._sanitise_mentions(_temp))
         if len("\n".join(output)) > 500:
             paginator = Paginator.create_from_list(self._client, output, page_size=500)
+            paginator.default_color = self.embed_color
             paginator.default_title = self.embed_title.format(
                 username=self._client.user.username
             )
@@ -98,7 +101,7 @@ class HelpCommand:
             embed = Embed(
                 title=self.embed_title.format(username=self._client.user.username),
                 description="\n".join(output),
-                color=BrandColors.BLURPLE,
+                color=self.embed_color,
             )
             await ctx.reply(embeds=embed)
 

--- a/molter/help.py
+++ b/molter/help.py
@@ -130,7 +130,8 @@ class HelpCommand:
         out: dict[str, molter.MolterCommand] = {}
 
         for cmd in self._client.commands.values():
-            cmd: molter.MolterCommand
+            if not isinstance(cmd, molter.MolterCommand):
+                continue
 
             if not cmd.enabled and not self.show_disabled:
                 continue

--- a/molter/help.py
+++ b/molter/help.py
@@ -48,7 +48,7 @@ class HelpCommand:
         show_hidden: bool = False,
         run_checks: bool = False,
         show_self: bool = False,
-        show_params: bool = False,
+        show_usage: bool = False,
         show_aliases: bool = False,
         show_prefix: bool = False,
         embed_title: str | None = None,
@@ -58,7 +58,7 @@ class HelpCommand:
         self.show_hidden = show_hidden
         self.run_checks = run_checks
         self.show_self = show_self
-        self.show_params = show_params
+        self.show_usage = show_usage
         self.show_aliases = show_aliases
         self.show_prefix = show_prefix
         self.embed_title = embed_title or "{username} Help Command"
@@ -203,9 +203,6 @@ class HelpCommand:
         if cmd.aliases and self.show_aliases:
             _temp += "|" + "|".join([f"`{a}`" for a in cmd.aliases])
 
-        if cmd.params and self.show_params:
-            for param in cmd.params:
-                wrapper = ("[", "]") if param.optional else ("<", ">")
-                _temp += f" `{wrapper[0]}{param.name}{wrapper[1]}`"
-
+        if cmd.usage and self.show_usage:
+            _temp += f" {cmd.usage}"
         return _temp


### PR DESCRIPTION
This is a basic implementation of a help command to tick off one of your points in #3. 

Pre-merge utilisation of this is fairly simple

```python
class bot(Snake):
    def __init__(sefl, ...):
        help = HelpCommand(self, show_params=True, ...)
        help.register()
```

To modify it, pre-merge, i really think just overriding is the way to go. Post merge i would like to introduce some sort of client method to modify help. 

This pr is dependant on dev-latest of dis-snake. Specifically https://github.com/Discord-Snake-Pit/Dis-Snek/commit/af6402230b409be638f45e12f80710dc99e2efb2