### PR TITLE
feat: annotation > converter specifiers

### DIFF
--- a/molter/command.py
+++ b/molter/command.py
@@ -805,7 +805,9 @@ def register_converter(anno_type: type, converter: type[Converter]) -> Callable[
         converter (`type[Converter]`): The converter to use for the type.
 
     Returns:
-        `Callable[..., Callable | MolterCommand]`: Either the callback or the command.
+        `Callable | MolterCommand`: Either the callback or the command.
+        If this is used after using the `molter.message_command` decorator, it will be a command.
+        Otherwise, it will be a callback.
     """
 
     def wrapper(command: MCT) -> MCT:

--- a/molter/command.py
+++ b/molter/command.py
@@ -149,7 +149,7 @@ def _get_from_anno_type(anno: Annotated, name: str) -> Any:
     return args[0]
 
 
-def _get_converter_function(anno: type[Converter], name: str) -> Callable[[MessageContext, str], Any]:
+def _get_converter_function(anno: type[Converter] | Converter, name: str) -> Callable[[MessageContext, str], Any]:
     num_params = len(inspect.signature(anno.convert).parameters.values())
 
     # if we have three parameters for the function, it's likely it has a self parameter
@@ -170,8 +170,8 @@ def _get_converter(anno: type, name: str, type_to_converter: dict[type, type[Con
     if typing.get_origin(anno) == Annotated:
         anno = _get_from_anno_type(anno, name)
 
-    if inspect.isclass(anno) and issubclass(anno, Converter):
-        return _get_converter_function(type(anno), name)
+    if isinstance(anno, Converter):
+        return _get_converter_function(anno, name)
     elif converter := type_to_converter.get(anno, None):
         return _get_converter_function(converter, name)
     elif typing.get_origin(anno) is Literal:

--- a/molter/command.py
+++ b/molter/command.py
@@ -804,6 +804,11 @@ def register_converter(anno_type: type, converter: type[Converter]) -> Callable[
             command._type_to_converter = {anno_type: converter}
 
         if isinstance(command, MolterCommand):
+            # yes, this sucks, but we need to re-analyze params just to make sure all
+            # annotations get converted with the new converter injection
+            # when this is merged with dis-snek, parameters will be analyzed either
+            # when the client reads its own commands or when a scale is loaded,
+            # instead of on creation. that will remove the need for this
             command.parse_parameters(has_self=_is_nested(command.callback))
 
         return command

--- a/molter/command.py
+++ b/molter/command.py
@@ -604,8 +604,7 @@ class MolterCommand(MessageCommand):
             subcommand's checks are checked. Defaults to True.
 
             type_to_converter (`dict[type, type[Converter]]`, optional): A dict
-            that specifies how to convert an type/annotation in a Molter commnad
-            from a message argument via converters. This allows you to use
+            that associates converters for types. This allows you to use
             native type annotations without needing to use `typing.Annotated`.
             If this is not set, only dis-snek classes will be converted using
             built-in converters.
@@ -760,8 +759,7 @@ def message_command(
         subcommand's checks are checked. Defaults to True.
 
         type_to_converter (`dict[type, type[Converter]]`, optional): A dict
-        that specifies how to convert an type/annotation in a Molter commnad
-        from a message argument via converters. This allows you to use
+        that associates converters for types. This allows you to use
         native type annotations without needing to use `typing.Annotated`.
         If this is not set, only dis-snek classes will be converted using
         built-in converters.
@@ -797,6 +795,19 @@ MCT = TypeVar("MCT", Callable, MolterCommand)
 
 
 def register_converter(anno_type: type, converter: type[Converter]) -> Callable[..., MCT]:
+    """
+    A decorator that allows you to register converters for a type for a specific command.
+
+    This allows for native type annotations without needing to use `typing.Annotated`.
+
+    Args:
+        anno_type (`type`): The type to register for.
+        converter (`type[Converter]`): The converter to use for the type.
+
+    Returns:
+        `Callable[..., Callable | MolterCommand]`: Either the callback or the command.
+    """
+
     def wrapper(command: MCT) -> MCT:
         if hasattr(command, "_type_to_converter"):
             command._type_to_converter[anno_type] = converter

--- a/molter/command.py
+++ b/molter/command.py
@@ -24,7 +24,7 @@ __all__ = (
     "MolterCommand",
     "message_command",
     "msg_command",
-    "convert",
+    "register_converter",
 )
 
 # turns out dis-snek's args thinks newlines are the start of new arguments
@@ -789,7 +789,7 @@ msg_command = message_command
 MCT = TypeVar("MCT", Callable, MolterCommand)
 
 
-def convert(annotation_type: type, converter: type[Converter]) -> Callable[..., MCT]:
+def register_converter(annotation_type: type, converter: type[Converter]) -> Callable[..., MCT]:
     def wrapper(command: MCT) -> MCT:
         if hasattr(command, "_anno_to_converter"):
             command._anno_to_converter[annotation_type] = converter


### PR DESCRIPTION
An idea discussed on the `dis-snek` server was the idea to allow normal annotations to be use in Molter commands by tying a converter to them. This is what is done for `dis-snek` objects, actually, but allowing user-defined "injections" would be nice as well.

Take, for example:

```python

@molter.msg_command()
@molter.register_converter(CustomClass, CustomClassConverter)
async def test(ctx: Context, class_var: CustomClass):
    ...
```

Molter would be able to take care of the conversion just with that decorator.

This PR *is not done* and in fact is just a draft. Reviews and contributions are encouraged.
